### PR TITLE
FIX: Use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 
 descr = """Experimental code for MEG and EEG data analysis."""
 


### PR DESCRIPTION
We should use `setuptools` so people can use `python setup.py develop`