### PR TITLE
porting cwt_morlet to new func

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ env:
     # Note that we don't run coverage on Py3k anyway because it slows our tests
     # by a factor of 2 (!), so we make this our "from install dir" run.
     #
-    # If we change the old-version run to be a different Python version
-    # from 2.6, then we need to update mne.utils.clean_warning_registry.
-    #
     # Run one test (3.5) with a non-default stim channel to make sure our
     # tests are explicit about channels.
     #
@@ -27,7 +24,6 @@ env:
     - PYTHON=2.7 TEST_LOCATION=src NUMPY="=1.9" SCIPY="=0.17"
     - PYTHON=2.7 TEST_LOCATION=install NUMPY="=1.9" SCIPY="=0.17"
     - PYTHON=3.5 TEST_LOCATION=src
-    - PYTHON=2.6 TEST_LOCATION=src NUMPY="=1.7" SCIPY="=0.11" MPL="=1.1" LIBPNG="=1.5" SKLEARN="=0.11" PANDAS="=0.8"
 
 # Setup anaconda
 before_install:

--- a/mne_sandbox/connectivity/cfc.py
+++ b/mne_sandbox/connectivity/cfc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mne.time_frequency import cwt_morlet
+from mne.time_frequency.tfr import _compute_tfr
 from mne.preprocessing import peak_finder
 from mne.utils import ProgressBar, logger
 from scipy.signal import hilbert
@@ -580,8 +580,8 @@ def _extract_phase_and_amp(data_ph, data_am, sfreq, freqs_phase,
     from sklearn.preprocessing import scale
 
     # Morlet transform to get complex representation
-    band_ph = cwt_morlet(data_ph, sfreq, freqs_phase)
-    band_amp = cwt_morlet(data_am, sfreq, freqs_amp)
+    band_ph = _compute_tfr([data_ph], freqs_phase, sfreq, method='morlet')[0]
+    band_amp = _compute_tfr([data_ph], freqs_amp, sfreq, method='morlet')[0]
 
     # Calculate the phase/amplitude of relevant signals across epochs
     band_ph_stacked = np.hstack(np.real(band_ph))


### PR DESCRIPTION
I think this addresses #21 . I'm using `_compute_tfr` now, which requires 3D input, thus the kind of awkward listing and de-listing of the inputs. That look correct?
